### PR TITLE
Update danmaQ URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Good luck, and have fun!
 
 ## Client
 
-The official desktop client is available at https://github.com/bigeagle/danmaQ 
+The official desktop client is available at https://github.com/tuna/danmaQ 


### PR DESCRIPTION
It's now under tuna umbrella.