### PR TITLE
changed default addr configuration in accordance with gevent.pywsgi

### DIFF
--- a/gdanmaku/__init__.py
+++ b/gdanmaku/__init__.py
@@ -52,7 +52,7 @@ from . import wechat
 
 def main():
     http_server = WSGIServer(('', 5000), app)
-    print("Serving at 0.0.0.0:5000")
+    print("Serving at localhost:5000")
     http_server.serve_forever()
 
 

--- a/gdanmaku/__init__.py
+++ b/gdanmaku/__init__.py
@@ -51,8 +51,8 @@ from . import api
 from . import wechat
 
 def main():
-    http_server = WSGIServer(('', 5000), app)
-    print("Serving at localhost:5000")
+    http_server = WSGIServer(('0.0.0.0', 5000), app)
+    print("Serving at 0.0.0.0:5000")
     http_server.serve_forever()
 
 


### PR DESCRIPTION
In newer versions of gevent.pywsgi.WSGIServer, when listening address is not specified, it will only listen to ipv6(more accurately ::1). Since it is impractical to assume that both server and clients have access to ipv6 newtorks, I changed the default config to ipv4 loopback address.