### PR TITLE
修复了微信功能与Windows平台下的配置问题

### DIFF
--- a/gdanmaku/__init__.py
+++ b/gdanmaku/__init__.py
@@ -52,7 +52,7 @@ from . import wechat
 
 def main():
     http_server = WSGIServer(('', 5000), app)
-    print("Serving at 0.0.0.0:5000")
+    print("Serving at localhost:5000")
     http_server.serve_forever()
 
 

--- a/gdanmaku/__init__.py
+++ b/gdanmaku/__init__.py
@@ -51,8 +51,8 @@ from . import api
 from . import wechat
 
 def main():
-    http_server = WSGIServer(('', 5000), app)
-    print("Serving at localhost:5000")
+    http_server = WSGIServer(('0.0.0.0', 5000), app)
+    print("Serving at 0.0.0.0:5000")
     http_server.serve_forever()
 
 

--- a/gdanmaku/wechat.py
+++ b/gdanmaku/wechat.py
@@ -55,9 +55,12 @@ def api_wechat_handle():
     cm = g.channel_manager
 
     ch_name = g.r.get(redis_key(FromUserName + ".ch_name"))
-    ch_key = g.r.get(redis_key(FromUserName + ".ch_key")) or ''
+    ch_key = g.r.get(redis_key(FromUserName + ".ch_key"))
+    ch_key = ch_key.decode() if ch_key is not None else ''
     ch_pos = g.r.get(redis_key(FromUserName + ".ch_pos"))
+    if ch_pos is not None: ch_pos = ch_pos.decode()
     ch_color = g.r.get(redis_key(FromUserName + ".ch_color"))
+    if ch_color is not None: ch_color = ch_color.decode()
 
     if ch_name is None:
         return make_reply(
@@ -173,7 +176,7 @@ def wechat_verify():
     timestamp = query.get('timestamp', '')
     nonce = query.get('nonce', '')
     s = ''.join(sorted([timestamp, nonce, token]))
-    return hashlib.sha1(s).hexdigest() == signature
+    return hashlib.sha1(s.encode()).hexdigest() == signature
 
 
 def make_reply(touser, fromuser, content):


### PR DESCRIPTION
如题，从py2升级到py3.7后，wechat.py内与字符串相关的代码并没有更新，导致微信功能不可用，在这里修复了，同时包含之前 #27 提到的设置瑕疵。